### PR TITLE
PIZ4: Create a CI job with GitHub actions to run the tests and coverage when a PR is created

### DIFF
--- a/.github/workflows/pytest_ci.yml
+++ b/.github/workflows/pytest_ci.yml
@@ -1,0 +1,29 @@
+name: Pytest CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest-cov
+
+      - name: Run tests and coverage
+        run: |
+          pytest --cov=./app/test --cov-fail-under=80 --cov-report=term-missing > pytest-coverage-results.txt
+
+      - name: Pytest coverage comment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-coverage-path: pytest-coverage-results.txt


### PR DESCRIPTION
**Ticket:**

[PIZ4 - Increase test coverage](https://trello.com/c/pAmuET56)

**Activities done:**

- The CI created supports at least 80% total coverage
- A Pytest Coverage Comment was included to show the coverage results in each PR
- [Tests for size service were included in this PR](https://github.com/kjduy/python-pizza-planet/pull/2/files#diff-be6434de432533b636c0035de576a1cce4cfc6e03140b6bc11e3f422b4dcfafe)
- [Tests for order service were included in this PR](https://github.com/kjduy/python-pizza-planet/pull/4/files#diff-7d9d24268caebe94e0cc222feb26802956be937e8a7e980231fe85cc4a0110c4)

**Changed files:**

- .github/workflows/pytest_ci.yml